### PR TITLE
Refactor factory pattern with new naming conventions and move respons…

### DIFF
--- a/InventoryManagementAPI/Controllers/ReportController.cs
+++ b/InventoryManagementAPI/Controllers/ReportController.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Authorization;
 using InventoryManagementAPI.DTOs.Product;
 using InventoryManagementAPI.Services;
+using InventoryManagementAPI.Factories;
 
 namespace InventoryManagementAPI.Controllers
 {
@@ -12,11 +13,15 @@ namespace InventoryManagementAPI.Controllers
     {
         private readonly IProductService _productService;
         private readonly IStockMovementService _stockMovementService;
+        private readonly IProductModelFactory _productModelFactory;
+        private readonly IStockMovementModelFactory _stockMovementModelFactory;
 
-        public ReportController(IProductService productService, IStockMovementService stockMovementService)
+        public ReportController(IProductService productService, IStockMovementService stockMovementService, IProductModelFactory productModelFactory, IStockMovementModelFactory stockMovementModelFactory)
         {
             _productService = productService;
             _stockMovementService = stockMovementService;
+            _productModelFactory = productModelFactory;
+            _stockMovementModelFactory = stockMovementModelFactory;
         }
 
         [HttpGet("low-stock")]
@@ -29,14 +34,16 @@ namespace InventoryManagementAPI.Controllers
             };
 
             var products = await _productService.SearchProductsAsync(searchRequest);
-            return Ok(products);
+            var model = _productModelFactory.PrepareProductListResponseModel(products);
+            return Ok(model);
         }
 
         [HttpGet("stock-movements/{productId}")]
         public async Task<IActionResult> GetProductStockMovements(int productId, [FromQuery] int count = 10)
         {
             var stockMovements = await _stockMovementService.GetLastStockMovementsAsync(productId, count);
-            return Ok(stockMovements);
+            var model = _stockMovementModelFactory.PrepareStockMovementListResponseModel(stockMovements);
+            return Ok(model);
         }
     }
 }

--- a/InventoryManagementAPI/Factories/AuthResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/AuthResponseFactory.cs
@@ -3,9 +3,9 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public class AuthResponseFactory : IAuthResponseFactory
+    public class AuthModelFactory : IAuthModelFactory
     {
-        public AuthResponseDto CreateAuthResponse(User user, string token, DateTime expiresAt)
+        public AuthResponseDto PrepareAuthResponseModel(User user, string token, DateTime expiresAt)
         {
             return new AuthResponseDto
             {

--- a/InventoryManagementAPI/Factories/IAuthResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/IAuthResponseFactory.cs
@@ -3,8 +3,8 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public interface IAuthResponseFactory
+    public interface IAuthModelFactory
     {
-        AuthResponseDto CreateAuthResponse(User user, string token, DateTime expiresAt);
+        AuthResponseDto PrepareAuthResponseModel(User user, string token, DateTime expiresAt);
     }
 }

--- a/InventoryManagementAPI/Factories/IProductResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/IProductResponseFactory.cs
@@ -3,10 +3,10 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public interface IProductResponseFactory
+    public interface IProductModelFactory
     {
-        ProductResponseDto CreateProductResponse(Product product);
-        ProductResponseDto CreateProductResponse(Product product, Supplier supplier);
-        IEnumerable<ProductResponseDto> CreateProductResponses(IEnumerable<Product> products);
+        ProductResponseDto PrepareProductResponseModel(Product product);
+        ProductResponseDto PrepareProductResponseModel(Product product, Supplier supplier);
+        IEnumerable<ProductResponseDto> PrepareProductListResponseModel(IEnumerable<Product> products);
     }
 }

--- a/InventoryManagementAPI/Factories/IRoleResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/IRoleResponseFactory.cs
@@ -3,9 +3,9 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public interface IRoleResponseFactory
+    public interface IRoleModelFactory
     {
-        RoleResponseDto CreateRoleResponse(UserRole role);
-        IEnumerable<RoleResponseDto> CreateRoleResponses(IEnumerable<UserRole> roles);
+        RoleResponseDto PrepareRoleResponseModel(UserRole role);
+        IEnumerable<RoleResponseDto> PrepareRoleListResponseModel(IEnumerable<UserRole> roles);
     }
 }

--- a/InventoryManagementAPI/Factories/IStockMovementResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/IStockMovementResponseFactory.cs
@@ -3,9 +3,9 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public interface IStockMovementResponseFactory
+    public interface IStockMovementModelFactory
     {
-        StockMovementResponseDto CreateStockMovementResponse(StockMovement stockMovement);
-        IEnumerable<StockMovementResponseDto> CreateStockMovementResponses(IEnumerable<StockMovement> stockMovements);
+        StockMovementResponseDto PrepareStockMovementResponseModel(StockMovement stockMovement);
+        IEnumerable<StockMovementResponseDto> PrepareStockMovementListResponseModel(IEnumerable<StockMovement> stockMovements);
     }
 }

--- a/InventoryManagementAPI/Factories/ISupplierResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/ISupplierResponseFactory.cs
@@ -3,9 +3,9 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public interface ISupplierResponseFactory
+    public interface ISupplierModelFactory
     {
-        SupplierResponseDto CreateSupplierResponse(Supplier supplier);
-        IEnumerable<SupplierResponseDto> CreateSupplierResponses(IEnumerable<Supplier> suppliers);
+        SupplierResponseDto PrepareSupplierResponseModel(Supplier supplier);
+        IEnumerable<SupplierResponseDto> PrepareSupplierListResponseModel(IEnumerable<Supplier> suppliers);
     }
 }

--- a/InventoryManagementAPI/Factories/IUserResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/IUserResponseFactory.cs
@@ -3,10 +3,10 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public interface IUserResponseFactory
+    public interface IUserModelFactory
     {
-        UserResponseDto CreateUserResponse(User user, IEnumerable<string> roleNames);
-        UserResponseDto CreateUserResponse(User user, string roleName);
-        IEnumerable<UserResponseDto> CreateUserResponses(IEnumerable<User> users);
+        UserResponseDto PrepareUserResponseModel(User user, string roleName);
+        UserResponseDto PrepareUserResponseModel(User user);
+        IEnumerable<UserResponseDto> PrepareUserListResponseModel(IEnumerable<User> users);
     }
 }

--- a/InventoryManagementAPI/Factories/ProductResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/ProductResponseFactory.cs
@@ -3,9 +3,9 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public class ProductResponseFactory : IProductResponseFactory
+    public class ProductModelFactory : IProductModelFactory
     {
-        public ProductResponseDto CreateProductResponse(Product product)
+        public ProductResponseDto PrepareProductResponseModel(Product product)
         {
             return new ProductResponseDto
             {
@@ -20,7 +20,7 @@ namespace InventoryManagementAPI.Factories
             };
         }
 
-        public ProductResponseDto CreateProductResponse(Product product, Supplier supplier)
+        public ProductResponseDto PrepareProductResponseModel(Product product, Supplier supplier)
         {
             return new ProductResponseDto
             {
@@ -35,9 +35,9 @@ namespace InventoryManagementAPI.Factories
             };
         }
 
-        public IEnumerable<ProductResponseDto> CreateProductResponses(IEnumerable<Product> products)
+        public IEnumerable<ProductResponseDto> PrepareProductListResponseModel(IEnumerable<Product> products)
         {
-            return products.Select(CreateProductResponse);
+            return products.Select(PrepareProductResponseModel);
         }
     }
 }

--- a/InventoryManagementAPI/Factories/RoleResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/RoleResponseFactory.cs
@@ -3,20 +3,22 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public class RoleResponseFactory : IRoleResponseFactory
+    public class RoleModelFactory : IRoleModelFactory
     {
-        public RoleResponseDto CreateRoleResponse(UserRole role)
+        public RoleResponseDto PrepareRoleResponseModel(UserRole role)
         {
             return new RoleResponseDto
             {
                 Id = role.Id,
-                Name = role.Name
+                Name = role.Name,
+                Description = role.Description,
+                CreatedOn = role.CreatedOn
             };
         }
 
-        public IEnumerable<RoleResponseDto> CreateRoleResponses(IEnumerable<UserRole> roles)
+        public IEnumerable<RoleResponseDto> PrepareRoleListResponseModel(IEnumerable<UserRole> roles)
         {
-            return roles.Select(CreateRoleResponse);
+            return roles.Select(PrepareRoleResponseModel);
         }
     }
 }

--- a/InventoryManagementAPI/Factories/StockMovementResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/StockMovementResponseFactory.cs
@@ -3,9 +3,9 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public class StockMovementResponseFactory : IStockMovementResponseFactory
+    public class StockMovementModelFactory : IStockMovementModelFactory
     {
-        public StockMovementResponseDto CreateStockMovementResponse(StockMovement stockMovement)
+        public StockMovementResponseDto PrepareStockMovementResponseModel(StockMovement stockMovement)
         {
             return new StockMovementResponseDto
             {
@@ -23,9 +23,9 @@ namespace InventoryManagementAPI.Factories
             };
         }
 
-        public IEnumerable<StockMovementResponseDto> CreateStockMovementResponses(IEnumerable<StockMovement> stockMovements)
+        public IEnumerable<StockMovementResponseDto> PrepareStockMovementListResponseModel(IEnumerable<StockMovement> stockMovements)
         {
-            return stockMovements.Select(CreateStockMovementResponse);
+            return stockMovements.Select(PrepareStockMovementResponseModel);
         }
     }
 }

--- a/InventoryManagementAPI/Factories/SupplierResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/SupplierResponseFactory.cs
@@ -3,9 +3,9 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public class SupplierResponseFactory : ISupplierResponseFactory
+    public class SupplierModelFactory : ISupplierModelFactory
     {
-        public SupplierResponseDto CreateSupplierResponse(Supplier supplier)
+        public SupplierResponseDto PrepareSupplierResponseModel(Supplier supplier)
         {
             return new SupplierResponseDto
             {
@@ -19,9 +19,9 @@ namespace InventoryManagementAPI.Factories
             };
         }
 
-        public IEnumerable<SupplierResponseDto> CreateSupplierResponses(IEnumerable<Supplier> suppliers)
+        public IEnumerable<SupplierResponseDto> PrepareSupplierListResponseModel(IEnumerable<Supplier> suppliers)
         {
-            return suppliers.Select(CreateSupplierResponse);
+            return suppliers.Select(PrepareSupplierResponseModel);
         }
     }
 }

--- a/InventoryManagementAPI/Factories/UserResponseFactory.cs
+++ b/InventoryManagementAPI/Factories/UserResponseFactory.cs
@@ -3,9 +3,9 @@ using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Factories
 {
-    public class UserResponseFactory : IUserResponseFactory
+    public class UserModelFactory : IUserModelFactory
     {
-        public UserResponseDto CreateUserResponse(User user, IEnumerable<string> roleNames)
+        public UserResponseDto PrepareUserResponseModel(User user, string roleName)
         {
             return new UserResponseDto
             {
@@ -13,19 +13,27 @@ namespace InventoryManagementAPI.Factories
                 Email = user.Email,
                 FirstName = user.FirstName,
                 LastName = user.LastName,
-                RoleNames = roleNames.ToList(),
+                RoleNames = new List<string> { roleName },
                 CreatedOn = user.CreatedOn
             };
         }
 
-        public UserResponseDto CreateUserResponse(User user, string roleName)
+        public UserResponseDto PrepareUserResponseModel(User user)
         {
-            return CreateUserResponse(user, new List<string> { roleName });
+            return new UserResponseDto
+            {
+                Id = user.Id,
+                Email = user.Email,
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                RoleNames = user.UserRoleMappings?.Select(urm => urm.Role.Name).ToList() ?? new List<string>(),
+                CreatedOn = user.CreatedOn
+            };
         }
 
-        public IEnumerable<UserResponseDto> CreateUserResponses(IEnumerable<User> users)
+        public IEnumerable<UserResponseDto> PrepareUserListResponseModel(IEnumerable<User> users)
         {
-            return users.Select(u => CreateUserResponse(u, u.UserRoleMappings.Select(urm => urm.Role.Name)));
+            return users.Select(PrepareUserResponseModel);
         }
     }
 }

--- a/InventoryManagementAPI/Program.cs
+++ b/InventoryManagementAPI/Program.cs
@@ -46,12 +46,12 @@ builder.Services.AddScoped<IProductService, ProductService>();
 builder.Services.AddScoped<ISupplierService, SupplierService>();
 builder.Services.AddScoped<IStockMovementService, StockMovementService>();
 
-builder.Services.AddScoped<IAuthResponseFactory, AuthResponseFactory>();
-builder.Services.AddScoped<IUserResponseFactory, UserResponseFactory>();
-builder.Services.AddScoped<IRoleResponseFactory, RoleResponseFactory>();
-builder.Services.AddScoped<IProductResponseFactory, ProductResponseFactory>();
-builder.Services.AddScoped<ISupplierResponseFactory, SupplierResponseFactory>();
-builder.Services.AddScoped<IStockMovementResponseFactory, StockMovementResponseFactory>();
+builder.Services.AddScoped<IAuthModelFactory, AuthModelFactory>();
+builder.Services.AddScoped<IUserModelFactory, UserModelFactory>();
+builder.Services.AddScoped<IRoleModelFactory, RoleModelFactory>();
+builder.Services.AddScoped<IProductModelFactory, ProductModelFactory>();
+builder.Services.AddScoped<ISupplierModelFactory, SupplierModelFactory>();
+builder.Services.AddScoped<IStockMovementModelFactory, StockMovementModelFactory>();
 
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/InventoryManagementAPI/Services/IAuthService.cs
+++ b/InventoryManagementAPI/Services/IAuthService.cs
@@ -1,10 +1,11 @@
 using InventoryManagementAPI.DTOs.Auth;
+using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Services
 {
     public interface IAuthService
     {
-        Task<AuthResponseDto?> RegisterAsync(RegisterRequestDto request);
-        Task<AuthResponseDto?> LoginAsync(LoginRequestDto request);
+        Task<(User?, string?)> RegisterAsync(RegisterRequestDto request);
+        Task<(User?, string?)> LoginAsync(LoginRequestDto request);
     }
 }

--- a/InventoryManagementAPI/Services/IProductService.cs
+++ b/InventoryManagementAPI/Services/IProductService.cs
@@ -1,14 +1,15 @@
 using InventoryManagementAPI.DTOs.Product;
+using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Services
 {
     public interface IProductService
     {
-        Task<ProductResponseDto?> CreateProductAsync(CreateProductRequestDto request);
-        Task<ProductResponseDto?> UpdateProductAsync(int id, UpdateProductRequestDto request);
+        Task<Product?> CreateProductAsync(CreateProductRequestDto request);
+        Task<Product?> UpdateProductAsync(int id, UpdateProductRequestDto request);
         Task<bool> DeleteProductAsync(int id);
-        Task<ProductResponseDto?> GetProductByIdAsync(int id);
-        Task<IEnumerable<ProductResponseDto>> GetAllProductsAsync();
-        Task<IEnumerable<ProductResponseDto>> SearchProductsAsync(ProductSearchRequestDto searchRequest);
+        Task<Product?> GetProductByIdAsync(int id);
+        Task<IEnumerable<Product>> GetAllProductsAsync();
+        Task<IEnumerable<Product>> SearchProductsAsync(ProductSearchRequestDto searchRequest);
     }
 }

--- a/InventoryManagementAPI/Services/IRoleManagementService.cs
+++ b/InventoryManagementAPI/Services/IRoleManagementService.cs
@@ -5,9 +5,9 @@ namespace InventoryManagementAPI.Services
 {
     public interface IRoleManagementService
     {
-        Task<RoleResponseDto?> CreateRoleAsync(CreateRoleRequestDto request);
-        Task<RoleResponseDto?> UpdateRoleAsync(int roleId, UpdateRoleRequestDto request);
+        Task<UserRole?> CreateRoleAsync(CreateRoleRequestDto request);
+        Task<UserRole?> UpdateRoleAsync(int roleId, UpdateRoleRequestDto request);
         Task<bool> DeleteRoleAsync(int roleId);
-        Task<IEnumerable<RoleResponseDto>> GetAllRolesAsync();
+        Task<IEnumerable<UserRole>> GetAllRolesAsync();
     }
 }

--- a/InventoryManagementAPI/Services/IStockMovementService.cs
+++ b/InventoryManagementAPI/Services/IStockMovementService.cs
@@ -1,10 +1,11 @@
 using InventoryManagementAPI.DTOs.StockMovement;
+using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Services
 {
     public interface IStockMovementService
     {
-        Task<StockMovementResponseDto?> CreateStockMovementAsync(CreateStockMovementRequestDto request, int userId);
-        Task<IEnumerable<StockMovementResponseDto>> GetLastStockMovementsAsync(int productId, int count = 10);
+        Task<StockMovement?> CreateStockMovementAsync(CreateStockMovementRequestDto request, int userId);
+        Task<IEnumerable<StockMovement>> GetLastStockMovementsAsync(int productId, int count = 10);
     }
 }

--- a/InventoryManagementAPI/Services/ISupplierService.cs
+++ b/InventoryManagementAPI/Services/ISupplierService.cs
@@ -1,13 +1,14 @@
 using InventoryManagementAPI.DTOs.Supplier;
+using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Services
 {
     public interface ISupplierService
     {
-        Task<SupplierResponseDto?> CreateSupplierAsync(CreateSupplierRequestDto request);
-        Task<SupplierResponseDto?> UpdateSupplierAsync(int id, UpdateSupplierRequestDto request);
+        Task<Supplier?> CreateSupplierAsync(CreateSupplierRequestDto request);
+        Task<Supplier?> UpdateSupplierAsync(int id, UpdateSupplierRequestDto request);
         Task<bool> DeleteSupplierAsync(int id);
-        Task<SupplierResponseDto?> GetSupplierByIdAsync(int id);
-        Task<IEnumerable<SupplierResponseDto>> GetAllSuppliersAsync();
+        Task<Supplier?> GetSupplierByIdAsync(int id);
+        Task<IEnumerable<Supplier>> GetAllSuppliersAsync();
     }
 }

--- a/InventoryManagementAPI/Services/IUserManagementService.cs
+++ b/InventoryManagementAPI/Services/IUserManagementService.cs
@@ -1,12 +1,13 @@
 using InventoryManagementAPI.DTOs.User;
+using InventoryManagementAPI.Models;
 
 namespace InventoryManagementAPI.Services
 {
     public interface IUserManagementService
     {
-        Task<UserResponseDto?> CreateUserAsync(CreateUserRequestDto request);
-        Task<UserResponseDto?> UpdateUserRoleAsync(int userId, int roleId);
-        Task<IEnumerable<UserResponseDto>> GetAllUsersAsync();
+        Task<User?> CreateUserAsync(CreateUserRequestDto request);
+        Task<User?> UpdateUserRoleAsync(int userId, int roleId);
+        Task<IEnumerable<User>> GetAllUsersAsync();
         Task<bool> DeleteUserAsync(int userId);
     }
 }

--- a/InventoryManagementAPI/Services/RoleManagementService.cs
+++ b/InventoryManagementAPI/Services/RoleManagementService.cs
@@ -2,22 +2,19 @@ using Microsoft.EntityFrameworkCore;
 using InventoryManagementAPI.Data;
 using InventoryManagementAPI.DTOs.Role;
 using InventoryManagementAPI.Models;
-using InventoryManagementAPI.Factories;
 
 namespace InventoryManagementAPI.Services
 {
     public class RoleManagementService : IRoleManagementService
     {
         private readonly ApplicationDbContext _context;
-        private readonly IRoleResponseFactory _roleResponseFactory;
 
-        public RoleManagementService(ApplicationDbContext context, IRoleResponseFactory roleResponseFactory)
+        public RoleManagementService(ApplicationDbContext context)
         {
             _context = context;
-            _roleResponseFactory = roleResponseFactory;
         }
 
-        public async Task<RoleResponseDto?> CreateRoleAsync(CreateRoleRequestDto request)
+        public async Task<UserRole?> CreateRoleAsync(CreateRoleRequestDto request)
         {
             if (await _context.UserRoles.AnyAsync(r => r.Name == request.Name))
             {
@@ -26,16 +23,18 @@ namespace InventoryManagementAPI.Services
 
             var role = new UserRole
             {
-                Name = request.Name
+                Name = request.Name,
+                Description = request.Description,
+                CreatedOn = DateTime.UtcNow
             };
 
             _context.UserRoles.Add(role);
             await _context.SaveChangesAsync();
 
-            return _roleResponseFactory.CreateRoleResponse(role);
+            return role;
         }
 
-        public async Task<RoleResponseDto?> UpdateRoleAsync(int roleId, UpdateRoleRequestDto request)
+        public async Task<UserRole?> UpdateRoleAsync(int roleId, UpdateRoleRequestDto request)
         {
             var role = await _context.UserRoles.FindAsync(roleId);
             
@@ -50,15 +49,16 @@ namespace InventoryManagementAPI.Services
             }
 
             role.Name = request.Name;
+            role.Description = request.Description;
+
             await _context.SaveChangesAsync();
 
-            return _roleResponseFactory.CreateRoleResponse(role);
+            return role;
         }
 
         public async Task<bool> DeleteRoleAsync(int roleId)
         {
             var role = await _context.UserRoles.FindAsync(roleId);
-            
             if (role == null)
             {
                 return false;
@@ -72,15 +72,15 @@ namespace InventoryManagementAPI.Services
 
             _context.UserRoles.Remove(role);
             await _context.SaveChangesAsync();
+
             return true;
         }
 
-        public async Task<IEnumerable<RoleResponseDto>> GetAllRolesAsync()
+        public async Task<IEnumerable<UserRole>> GetAllRolesAsync()
         {
             var roles = await _context.UserRoles.ToListAsync();
 
-            return _roleResponseFactory.CreateRoleResponses(roles);
+            return roles;
         }
-
     }
 }

--- a/InventoryManagementAPI/Services/StockMovementService.cs
+++ b/InventoryManagementAPI/Services/StockMovementService.cs
@@ -2,22 +2,19 @@ using Microsoft.EntityFrameworkCore;
 using InventoryManagementAPI.Data;
 using InventoryManagementAPI.DTOs.StockMovement;
 using InventoryManagementAPI.Models;
-using InventoryManagementAPI.Factories;
 
 namespace InventoryManagementAPI.Services
 {
     public class StockMovementService : IStockMovementService
     {
         private readonly ApplicationDbContext _context;
-        private readonly IStockMovementResponseFactory _stockMovementResponseFactory;
 
-        public StockMovementService(ApplicationDbContext context, IStockMovementResponseFactory stockMovementResponseFactory)
+        public StockMovementService(ApplicationDbContext context)
         {
             _context = context;
-            _stockMovementResponseFactory = stockMovementResponseFactory;
         }
 
-        public async Task<StockMovementResponseDto?> CreateStockMovementAsync(CreateStockMovementRequestDto request, int userId)
+        public async Task<StockMovement?> CreateStockMovementAsync(CreateStockMovementRequestDto request, int userId)
         {
             using var transaction = await _context.Database.BeginTransactionAsync();
             
@@ -71,7 +68,7 @@ namespace InventoryManagementAPI.Services
                 stockMovement.Product = productWithSupplier;
                 stockMovement.CreatedByUser = user;
 
-                return _stockMovementResponseFactory.CreateStockMovementResponse(stockMovement);
+                return stockMovement;
             }
             catch
             {
@@ -80,7 +77,7 @@ namespace InventoryManagementAPI.Services
             }
         }
 
-        public async Task<IEnumerable<StockMovementResponseDto>> GetLastStockMovementsAsync(int productId, int count = 10)
+        public async Task<IEnumerable<StockMovement>> GetLastStockMovementsAsync(int productId, int count = 10)
         {
             var stockMovements = await _context.StockMovements
                 .Include(sm => sm.Product)
@@ -90,7 +87,7 @@ namespace InventoryManagementAPI.Services
                 .Take(count)
                 .ToListAsync();
 
-            return _stockMovementResponseFactory.CreateStockMovementResponses(stockMovements);
+            return stockMovements;
         }
     }
 }

--- a/InventoryManagementAPI/Services/SupplierService.cs
+++ b/InventoryManagementAPI/Services/SupplierService.cs
@@ -2,22 +2,19 @@ using Microsoft.EntityFrameworkCore;
 using InventoryManagementAPI.Data;
 using InventoryManagementAPI.DTOs.Supplier;
 using InventoryManagementAPI.Models;
-using InventoryManagementAPI.Factories;
 
 namespace InventoryManagementAPI.Services
 {
     public class SupplierService : ISupplierService
     {
         private readonly ApplicationDbContext _context;
-        private readonly ISupplierResponseFactory _supplierResponseFactory;
 
-        public SupplierService(ApplicationDbContext context, ISupplierResponseFactory supplierResponseFactory)
+        public SupplierService(ApplicationDbContext context)
         {
             _context = context;
-            _supplierResponseFactory = supplierResponseFactory;
         }
 
-        public async Task<SupplierResponseDto?> CreateSupplierAsync(CreateSupplierRequestDto request)
+        public async Task<Supplier?> CreateSupplierAsync(CreateSupplierRequestDto request)
         {
             if (await _context.Suppliers.AnyAsync(s => s.Email == request.Email))
             {
@@ -37,10 +34,10 @@ namespace InventoryManagementAPI.Services
             _context.Suppliers.Add(supplier);
             await _context.SaveChangesAsync();
 
-            return _supplierResponseFactory.CreateSupplierResponse(supplier);
+            return supplier;
         }
 
-        public async Task<SupplierResponseDto?> UpdateSupplierAsync(int id, UpdateSupplierRequestDto request)
+        public async Task<Supplier?> UpdateSupplierAsync(int id, UpdateSupplierRequestDto request)
         {
             var supplier = await _context.Suppliers.FindAsync(id);
             if (supplier == null)
@@ -61,7 +58,7 @@ namespace InventoryManagementAPI.Services
 
             await _context.SaveChangesAsync();
 
-            return _supplierResponseFactory.CreateSupplierResponse(supplier);
+            return supplier;
         }
 
         public async Task<bool> DeleteSupplierAsync(int id)
@@ -83,22 +80,16 @@ namespace InventoryManagementAPI.Services
             return true;
         }
 
-        public async Task<SupplierResponseDto?> GetSupplierByIdAsync(int id)
+        public async Task<Supplier?> GetSupplierByIdAsync(int id)
         {
             var supplier = await _context.Suppliers.FindAsync(id);
-            if (supplier == null)
-            {
-                return null;
-            }
-
-            return _supplierResponseFactory.CreateSupplierResponse(supplier);
+            return supplier;
         }
 
-        public async Task<IEnumerable<SupplierResponseDto>> GetAllSuppliersAsync()
+        public async Task<IEnumerable<Supplier>> GetAllSuppliersAsync()
         {
             var suppliers = await _context.Suppliers.ToListAsync();
-
-            return _supplierResponseFactory.CreateSupplierResponses(suppliers);
+            return suppliers;
         }
     }
 }


### PR DESCRIPTION
…e logic to controllers

- Rename all factories from *ResponseFactory to *ModelFactory
- Rename factory methods from Create*Response to Prepare*ResponseModel
- Update services to return domain models instead of DTOs
- Move DTO response preparation logic from services to controllers
- Update dependency injection registrations with new factory names
- Add collection methods like PrepareProductListResponseModel for GetAll endpoints
- Controllers now inject factories and handle response preparation
- Services focus on business logic and return domain entities